### PR TITLE
MULE-11289: renaming groupsIds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,44 +33,44 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.mule.extensions</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-extensions-api</artifactId>
             <version>${mule.sdk.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mule</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-api</artifactId>
             <version>${mule.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mule</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${mule.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mule.modules</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-spring-support</artifactId>
             <version>${mule.version}</version>
             <scope>provided</scope>
             <!--TODO MULE-9717-->
         </dependency>
         <dependency>
-            <groupId>org.mule</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-metadata-model-xml</artifactId>
             <version>${mule.metadata.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mule</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-metadata-model-java</artifactId>
             <version>${mule.metadata.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mule</groupId>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-metadata-model-json</artifactId>
             <version>${mule.metadata.version}</version>
             <scope>provided</scope>
@@ -106,7 +106,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.mule.extensions</groupId>
+                    <groupId>org.mule.runtime.plugins</groupId>
                     <artifactId>mule-extensions-maven-plugin</artifactId>
                     <version>${mule.extensions.maven.plugin.version}</version>
                     <extensions>true</extensions>
@@ -198,7 +198,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.mule.extensions</groupId>
+                <groupId>org.mule.runtime.plugins</groupId>
                 <artifactId>mule-extensions-maven-plugin</artifactId>
                 <version>${mule.extensions.maven.plugin.version}</version>
             </plugin>


### PR DESCRIPTION
depends on https://github.com/mulesoft/metadata-model-api/pull/62 and mulesoft/mule-api#169 and mulesoft/mule-extensions-api#271 and https://github.com/mulesoft/mule-extensions-maven-plugin/pull/37 and https://github.com/mulesoft/mule-extensions-parent/pull/11  and https://github.com/mulesoft/mule/pull/4213