### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,14 +94,7 @@
             <version>${mule.version}</version>
             <classifier>mule-service</classifier>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.services</groupId>
-            <artifactId>mule-service-scheduler</artifactId>
-            <version>${mule.version}</version>
-            <classifier>mule-service</classifier>
-            <scope>provided</scope>
-        </dependency>
+        </dependency>        
 
         <!--Test Dependencies-->
         <dependency>


### PR DESCRIPTION
_ Removing dependency to old scheduler service implementation