### PR TITLE
MULE-16417: Fix issues affecting mule-aggregators-module tests on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Java 11 Support-->
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-javaee</artifactId>
+            <version>${mule.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>


### PR DESCRIPTION
- Adding Mule's Java EE module for fixing tests issues with Java 11
 after  "JEP 320: Remove the Java EE and CORBA Modules"