### PR TITLE
MULE-18746: Classloading conflict in `mule-extensions-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,13 @@
                 <groupId>org.mule.runtime.plugins</groupId>
                 <artifactId>mule-extensions-maven-plugin</artifactId>
                 <version>${mule.extensions.maven.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mule.runtime</groupId>
+                        <artifactId>mule-dwb-api</artifactId>
+                        <version>${mule.weave.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <!-- Maven Plugins -->


### PR DESCRIPTION
because of `dwb-api`