### PR TITLE
Revert "MULE-19724: Exclude mule-sdk-api from the extensions parent of the SDK (#145) (#147)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,12 +159,6 @@
             <artifactId>mule-extensions-api</artifactId>
             <version>${mule.sdk.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mule.sdk</groupId>
-                    <artifactId>mule-sdk-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>


### PR DESCRIPTION


This reverts commit 9da8e9d186c20cad244c8e77e838388d7a379170.