### PR TITLE
Revert "MULE-19724: Exclude mule-sdk-api from the extensions parent of the SDK (#145)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,12 +159,6 @@
             <artifactId>mule-extensions-api</artifactId>
             <version>${mule.sdk.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mule.sdk</groupId>
-                    <artifactId>mule-sdk-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>


### PR DESCRIPTION
This reverts commit 84d0101c2ed8b75592719c2345f58703d978ebb8.