### PR TITLE
Revert "MULE-19724: Exclude mule-sdk-api from the extensions parent of the SDK (#145) (#146)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,12 +159,6 @@
             <artifactId>mule-extensions-api</artifactId>
             <version>${mule.sdk.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mule.sdk</groupId>
-                    <artifactId>mule-sdk-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>


### PR DESCRIPTION


This reverts commit 486b910d8e607cb0247e45c6c6e8102cbbc46480.