### PR TITLE
Revert "MULE-19724: Exclude mule-sdk-api from the extensions parent of the SDK (#151) (#152)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
         <mule.weave.version>2.4.0-SNAPSHOT</mule.weave.version>
         <mule.sdk.version>1.4.1-SNAPSHOT</mule.sdk.version>
         <mule.api.version>1.4.1-SNAPSHOT</mule.api.version>
-        <mule.sdk.api.version>0.4.0</mule.sdk.api.version>
         <mule.metadata.version>1.4.1-SNAPSHOT</mule.metadata.version>
         <mule.extensions.ast.loader.version>1.3.1-SNAPSHOT</mule.extensions.ast.loader.version>
         <mule.extensions.maven.plugin.version>1.4.1-SNAPSHOT</mule.extensions.maven.plugin.version>
@@ -160,12 +159,6 @@
             <artifactId>mule-extensions-api</artifactId>
             <version>${mule.sdk.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mule.sdk</groupId>
-                    <artifactId>mule-sdk-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
@@ -461,11 +454,6 @@
                         <groupId>cglib</groupId>
                         <artifactId>cglib</artifactId>
                         <version>${cglib.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.mule.sdk</groupId>
-                        <artifactId>mule-sdk-api</artifactId>
-                        <version>${mule.sdk.api.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION


This reverts commit 01c965d4e93e7b9436953307479816523c19fa06.