### PR TITLE
W-13588773: Replace all javax jars bundled in the runtime with the

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
             org.mule.runtime.ast.internal.extension.loader.ASTExtensionResourcesGeneratorAnnotationProcessor
         </extensionsAnnotationProcessor>
         <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
-        <java.xml.bind.version>2.3.1-MULE-001</java.xml.bind.version>
+        <java.xml.bind.version>2.3.8</java.xml.bind.version>
         <javax.activation.version>1.2.1</javax.activation.version>
         <exportedPackagesValidator.skip>false</exportedPackagesValidator.skip>
         <exportedPackagesValidator.strictValidation>false</exportedPackagesValidator.strictValidation>
@@ -557,7 +557,7 @@
                         <version>${mule.extensions.ast.loader.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>org.mule.glassfish.jaxb</groupId>
+                        <groupId>com.sun.xml.bind</groupId>
                         <artifactId>jaxb-runtime</artifactId>
                         <version>${java.xml.bind.version}</version>
                     </dependency>


### PR DESCRIPTION
jakarta equivalent

* Addendum: remove activation-api and leave just activation (ref: https://github.com/jakartaee/jaf-api/issues/18)